### PR TITLE
Lower JVM target version in Kotlin compiler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.08.04XX
+- Bug fix: Lower JVM requirements.
+
 ## 23.07.29XX
 - Great contribution from [rolandcheck](https://github.com/rolandcheck): New contextual action to automatically create a mediatR handler for a given request.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## 23.08.04XX
-- Bug fix: Lower JVM requirements.
+- Bug fixes.
 
 ## 23.07.29XX
 - Great contribution from [rolandcheck](https://github.com/rolandcheck): New contextual action to automatically create a mediatR handler for a given request.

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ compileKotlin {
     kotlinOptions { jvmTarget = "17" }
 }
 
+compileJava {
+    targetCompatibility = "17"
+}
+
 task setBuildTool {
     doLast {
         ext.args = []

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ sourceSets {
 }
 
 compileKotlin {
-    kotlinOptions { jvmTarget = "20" }
+    kotlinOptions { jvmTarget = "17" }
 }
 
 task setBuildTool {

--- a/devops/cicd/stages/build.yaml
+++ b/devops/cicd/stages/build.yaml
@@ -39,7 +39,7 @@ stages:
               azureResourceManagerEndpoint  : 'Azure (plugin-rider-pipeline)'
               azureStorageAccountName       : 'stpluginriderpipeline'
               azureContainerName            : 'jdk17'
-              azureCommonVirtualFile        : 'jdk_17.zip'
+              azureCommonVirtualFile        : 'jdk17.zip'
               jdkDestinationDirectory       : $(Agent.ToolsDirectory)/jdk
               cleanDestinationDirectory     : true
               

--- a/devops/cicd/stages/build.yaml
+++ b/devops/cicd/stages/build.yaml
@@ -33,13 +33,13 @@ stages:
   
           - task: JavaToolInstaller@0
             inputs:
-              versionSpec           : '20'
-              jdkArchitectureOption : 'x64'
+              versionSpec                   : '17'
+              jdkArchitectureOption         : 'x64'
               jdkSourceOption               : 'AzureStorage'
               azureResourceManagerEndpoint  : 'Azure (plugin-rider-pipeline)'
               azureStorageAccountName       : 'stpluginriderpipeline'
-              azureContainerName            : 'jdk20'
-              azureCommonVirtualFile        : 'jdk_20.zip'
+              azureContainerName            : 'jdk17'
+              azureCommonVirtualFile        : 'jdk_17.zip'
               jdkDestinationDirectory       : $(Agent.ToolsDirectory)/jdk
               cleanDestinationDirectory     : true
               
@@ -57,7 +57,7 @@ stages:
               tasks               : ':prepareSandbox'
               publishJUnitResults : false
               javaHomeOption      : 'Path'
-              jdkDirectory        : $(Agent.ToolsDirectory)/jdk/JAVA_HOME_20_X64_jdk_20_zip
+              jdkDirectory        : $(Agent.ToolsDirectory)/jdk/JAVA_HOME_17_X64_jdk_17_zip
           
           - task: CopyFiles@2
             displayName: 'copy .jar file'

--- a/devops/cicd/stages/build.yaml
+++ b/devops/cicd/stages/build.yaml
@@ -57,7 +57,7 @@ stages:
               tasks               : ':prepareSandbox'
               publishJUnitResults : false
               javaHomeOption      : 'Path'
-              jdkDirectory        : $(Agent.ToolsDirectory)/jdk/JAVA_HOME_17_X64_jdk_17_zip
+              jdkDirectory        : $(Agent.ToolsDirectory)/jdk/JAVA_HOME_17_X64_jdk17_zip
           
           - task: CopyFiles@2
             displayName: 'copy .jar file'

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Actions/GoToHandlrContextAction.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Actions/GoToHandlrContextAction.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 30/12/2021 @ 10:26
-// ==========================================================================
-
 using System;
 using JetBrains.Application.Progress;
 using JetBrains.Diagnostics;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/DefaultActions.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/DefaultActions.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 21:08
-// ==========================================================================
-
 using System;
 using JetBrains.TextControl;
 

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Diagnostics/Guard.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Diagnostics/Guard.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 21:13
-// ==========================================================================
-
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Diagnostics/Logger.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Diagnostics/Logger.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 19:39
-// ==========================================================================
-
 using JetBrains.Diagnostics;
 using NoSuchCompany.ReSharperPlugin.FindMyHandlR.Actions;
 

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/DeclaredElementExtensions.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/DeclaredElementExtensions.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 28/12/2021 @ 09:15
-// ==========================================================================
-
 using System.Linq;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Search/InheritorsConsumer.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Search/InheritorsConsumer.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 20:07
-// ==========================================================================
-
 using System.Collections.Generic;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Search;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/CSharpFileExtensions.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/CSharpFileExtensions.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 21:05
-// ==========================================================================
-
 using System;
 using System.Linq;
 using JetBrains.ReSharper.Psi.CSharp.Tree;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/IdentifierExtensions.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/IdentifierExtensions.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 20:09
-// ==========================================================================
-
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/NullIdentifier.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/Tree/NullIdentifier.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 20:32
-// ==========================================================================
-
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/TypeElementExtensions.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/ReSharper/Psi/TypeElementExtensions.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 28/12/2021 @ 09:05
-// ==========================================================================
-
 using JetBrains.ReSharper.Psi;
 
 namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.ReSharper.Psi

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Services/HandlrNavigator.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Services/HandlrNavigator.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 30/12/2021 @ 10:22
-// ==========================================================================
-
 using System;
 using JetBrains.Diagnostics;
 using JetBrains.ReSharper.Feature.Services.Navigation.NavigationExtensions;
@@ -50,7 +42,7 @@ namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services
 			if (!fileFound)
 				Logger.Instance.Log(LoggingLevel.WARN, "The C# source file of the MediatR handler could not be found.");
 			else
-				Logger.Instance.Log(LoggingLevel.WARN, $"The C# source file of the MediatR handler has been found: '{csharpFile!.GetSourceFile()!.DisplayName}'");
+				Logger.Instance.Log(LoggingLevel.INFO, $"The C# source file of the MediatR handler has been found: '{csharpFile!.GetSourceFile()!.DisplayName}'");
 
 			return (fileFound, csharpFile);
 		}
@@ -62,7 +54,7 @@ namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services
 			if (mediatrHandlerTypeElement is null)
 				Logger.Instance.Log(LoggingLevel.WARN, $"No MediatR handler using the type '{selectedIdentifier.Name}' has been found.");
 			else
-				Logger.Instance.Log(LoggingLevel.WARN, $"A MediatR handler using the type '{selectedIdentifier.Name}' has been found: '{mediatrHandlerTypeElement.GetClrName().FullName}'");
+				Logger.Instance.Log(LoggingLevel.INFO, $"A MediatR handler using the type '{selectedIdentifier.Name}' has been found: '{mediatrHandlerTypeElement.GetClrName().FullName}'");
 
 			return (mediatrHandlerTypeElement is not null, mediatrHandlerTypeElement);
 		}
@@ -74,7 +66,7 @@ namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services
 			if (treeNode is null)
 				Logger.Instance.Log(LoggingLevel.WARN, $"The tree node for the type '{typeElement.ShortName}' could not be found in the file '{csharpFile.GetSourceFile()!.DisplayName}'.");
 			else
-				Logger.Instance.Log(LoggingLevel.WARN, $"The tree node for the type '{typeElement.ShortName}' has been found in the file '{csharpFile.GetSourceFile()!.DisplayName}'.");
+				Logger.Instance.Log(LoggingLevel.INFO, $"The tree node for the type '{typeElement.ShortName}' has been found in the file '{csharpFile.GetSourceFile()!.DisplayName}'.");
 
 			return (treeNode is not null, treeNode);
 		}
@@ -83,7 +75,7 @@ namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services
 		{
 			try
 			{
-				Logger.Instance.Log(LoggingLevel.WARN, $"Looking for a possible MediatR handler that is using the type '{selectedIdentifier.Name}'");
+				Logger.Instance.Log(LoggingLevel.INFO, $"Looking for a possible MediatR handler that is using the type '{selectedIdentifier.Name}'");
 
 				//  Finds the MediatR handler for the selected request.
 				var (handlerTypeFound, mediatrHandlerTypeElement) = FindHandler(selectedIdentifier);

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Services/IHandlrNavigator.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Services/IHandlrNavigator.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 30/12/2021 @ 10:32
-// ==========================================================================
-
 using JetBrains.ReSharper.Psi.Tree;
 
 namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Services/IMediatR.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Services/IMediatR.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 20:00
-// ==========================================================================
-
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/dotnet/NoSuchCompany.MediatrPlugin/Services/MediatR.cs
+++ b/src/dotnet/NoSuchCompany.MediatrPlugin/Services/MediatR.cs
@@ -1,11 +1,3 @@
-// ==========================================================================
-// Copyright (C) 2021 by NoSuch Company.
-// All rights reserved.
-// May be used only in accordance with a valid Source Code License Agreement.
-// 
-// Last change: 27/12/2021 @ 20:16
-// ==========================================================================
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -147,6 +139,7 @@ namespace NoSuchCompany.ReSharperPlugin.FindMyHandlR.Services
                     .SelectMany(classDeclaration => classDeclaration.InheritedTypeUsagesEnumerable)
                     .Cast<IUserTypeUsage>()
                     .Select(userTypeUsage => userTypeUsage.ScalarTypeName)
+                    .Where(scalarTypeName => scalarTypeName.TypeArgumentList is not null)
                     .Select(scalarTypeName => scalarTypeName.TypeArgumentList)
                     .Select(typeArgumentList => typeArgumentList.Children())
                     .SelectMany(treeNode => treeNode)


### PR DESCRIPTION
The JVM target version under the Kotlin compiler options in build.gradle was changed from "20" to "17". This was necessary to ensure compatibility with systems running older JDK versions.