### PR TITLE
Update support for 2023.3 EAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 23.09.28XX
 - Support for 2023.3 EAP
-- 
+
 ## 23.08.04XX
 - Bug fixes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 23.09.28XX
+- Support for 2023.3 EAP
+- 
 ## 23.08.04XX
 - Bug fixes.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ PublishToken="_PLACEHOLDER_"
 #   Release:  2020.2
 #   Nightly:  2020.3-SNAPSHOT
 #   EAP:      2020.3-EAP2-SNAPSHOT
-ProductVersion=2023.2-EAP10-SNAPSHOT
+ProductVersion=2023.3-EAP1-SNAPSHOT
 
 # Kotlin 1.4 will bundle the stdlib dependency by default, causing problems with the version bundled with the IDE
 # https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/#stdlib-default

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SdkVersion>2023.3.0-EAP1</SdkVersion>
+    <SdkVersion>2023.3.0-EAP01</SdkVersion>
 
     <Title>MediatR Extensions</Title>
     <Description>Ever got frustrated to find out where was the handler of a MediatR's IRequest? Say no more. This plugin provides a context action to easily reach the handler of any MediatR request. Select your MediatR request, click on that action and boom you will be automatically transported to the appropriate handler.</Description>

--- a/src/dotnet/Plugin.props
+++ b/src/dotnet/Plugin.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SdkVersion>2023.2.0-EAP10</SdkVersion>
+    <SdkVersion>2023.3.0-EAP1</SdkVersion>
 
     <Title>MediatR Extensions</Title>
     <Description>Ever got frustrated to find out where was the handler of a MediatR's IRequest? Say no more. This plugin provides a context action to easily reach the handler of any MediatR request. Select your MediatR request, click on that action and boom you will be automatically transported to the appropriate handler.</Description>


### PR DESCRIPTION
Changes were made to support the 2023.3-EAP1 snapshot, across the CHANGELOG.md, gradle.properties, and Plugin.props files. This includes updates to ProductVersion and SdkVersion to reflect the new 2023.3-EAP1 support. This change is essential to keep the project current and compatible with the latest EAP snapshots.